### PR TITLE
Allow unspecified (null) HDFS host in Path URI if it is defined by fs.defaultFS

### DIFF
--- a/src/main/java/hdfs/jsr203/HadoopFileSystem.java
+++ b/src/main/java/hdfs/jsr203/HadoopFileSystem.java
@@ -101,7 +101,16 @@ public class HadoopFileSystem extends FileSystem {
 
 		// Create dynamic configuration
 		Configuration conf = new Configuration();
-		conf.set("fs.defaultFS", "hdfs://" + host + ":" + port + "/");
+    if (host == null) {
+      String defaultScheme =
+          org.apache.hadoop.fs.FileSystem.getDefaultUri(conf).getScheme();
+      if (!"hdfs".equals(defaultScheme)) {
+        throw new NullPointerException("Null host not permitted if default " +
+            "Hadoop filesystem is not HDFS.");
+      }
+    } else {
+      conf.set("fs.defaultFS", "hdfs://" + host + ":" + port + "/");
+    }
 
         this.fs = org.apache.hadoop.fs.FileSystem.get(conf);
         

--- a/src/test/java/hdfs/jsr203/TestFileSystem.java
+++ b/src/test/java/hdfs/jsr203/TestFileSystem.java
@@ -408,4 +408,10 @@ public class TestFileSystem extends TestHadoop {
     pathToTest.register(watcher, StandardWatchEventKinds.ENTRY_CREATE);
   }
 
+  @Test(expected=NullPointerException.class)
+  public void testNullHost() throws URISyntaxException, IOException {
+    URI uri = URI.create("hdfs:///tmp/testNullHost");
+    Paths.get(uri);
+  }
+
 }


### PR DESCRIPTION
The idea is that you shouldn't be compelled to provide the HDFS host if it's already set in the configuration (which it usually is on a cluster). So you should be able to say _hdfs:///path/to/file_

I've written a negative unit test for this. Writing a positive one is hard, as the Hadoop configuration files would need to be changed to write the fs.defaultFS URI for the mini cluster, and this would interfere with other tests. I've tested it manually though and it works fine.

