### PR TITLE
Handle case when port is not specified (equals -1).

### DIFF
--- a/src/main/java/hdfs/jsr203/HadoopPath.java
+++ b/src/main/java/hdfs/jsr203/HadoopPath.java
@@ -532,8 +532,14 @@ public class HadoopPath implements Path {
    * @return raw HDFS path object
    */
   public org.apache.hadoop.fs.Path getRawResolvedPath() {
-    return new org.apache.hadoop.fs.Path("hdfs://" + hdfs.getHost() + ":"
-        + hdfs.getPort() + new String(getResolvedPath()));
+    StringBuilder sb = new StringBuilder("hdfs://");
+    sb.append(hdfs.getHost());
+    if (hdfs.getPort() != -1) {
+      sb.append(':');
+      sb.append(hdfs.getPort());
+    }
+    sb.append(new String(getResolvedPath()));
+    return new org.apache.hadoop.fs.Path(sb.toString());
   }
 
   void delete() throws IOException {


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/3468.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/damiencarol/jsr203-hadoop/32)
<!-- Reviewable:end -->
