### PR TITLE
Fix moving directories

### DIFF
--- a/src/main/java/hdfs/jsr203/HadoopFileSystem.java
+++ b/src/main/java/hdfs/jsr203/HadoopFileSystem.java
@@ -776,10 +776,6 @@ public class HadoopFileSystem extends FileSystem {
             FileStatus eSrc = this.fs.getFileStatus(eSrc_path);
             if (!this.fs.exists(eSrc_path))
                 throw new NoSuchFileException(getString(src));
-            if (eSrc.isDirectory()) {    // specification says to create dst directory
-                createDirectory(dst);
-                return;
-            }
             boolean hasReplace = false;
             boolean hasCopyAttrs = false;
             for (CopyOption opt : options) {

--- a/src/test/java/hdfs/jsr203/TestFileSystem.java
+++ b/src/test/java/hdfs/jsr203/TestFileSystem.java
@@ -383,6 +383,29 @@ public class TestFileSystem extends TestHadoop {
   }
 
   @Test
+  public void testMoveDirectory() throws IOException {
+    Path pathSrcDir = Paths.get(clusterUri.resolve("/tmp/testSrcDir"));
+    Path pathSrcFile = pathSrcDir.resolve("test.txt");
+    Path pathDstDir = Paths.get(clusterUri.resolve("/tmp/testDstDir"));
+    Path pathDstFile = pathDstDir.resolve("test.txt");
+
+    OutputStream os = Files.newOutputStream(pathSrcFile);
+    os.write("write \n several \n things\n".getBytes());
+    os.close();
+
+    long size = Files.size(pathSrcFile);
+    Files.move(pathSrcDir, pathDstDir);
+    assertFalse(Files.exists(pathSrcDir));
+    assertTrue(Files.exists(pathDstFile));
+    assertEquals(size, Files.size(pathDstFile));
+
+    Files.deleteIfExists(pathSrcFile);
+    Files.deleteIfExists(pathSrcDir);
+    Files.deleteIfExists(pathDstFile);
+    Files.deleteIfExists(pathDstDir);
+  }
+
+  @Test
   @Ignore
   public void newWatchService() throws IOException {
     Path pathToTest = Paths.get(clusterUri);


### PR DESCRIPTION
I did not create an issue for this, but moving directories does not work as expected.

**Actual Behavior**
Moving a directory will create an empty directory at the destination.

**Expected Behavior**
Moving a directory should rename the source directory to the destination directory.

Code comment states that this is the behavior expected from the specification. I cannot confirm that. The documentation on `Files.move` explicitly states:
> [...] When invoked to move a directory that is not empty then the directory is moved if it does not require moving the entries in the directory. For example, renaming a directory on the same FileStore will usually not require moving the entries in the directory. [...]

https://download.oracle.com/otndocs/jcp/JCP_pages-nio-jdk7-final-oth-JSpec/index.html

I assume this error was introduced by copying `Files.copy`, where this behavior is actually expected.